### PR TITLE
refactor: replace custom mnemonic validation with bip39.validateMnemonic

### DIFF
--- a/src/app/wallet-setup/import-wallet.tsx
+++ b/src/app/wallet-setup/import-wallet.tsx
@@ -1,4 +1,5 @@
 import { SeedPhrase } from '@/components/SeedPhrase';
+import * as bip39 from 'bip39';
 import * as Clipboard from 'expo-clipboard';
 import { useDebouncedNavigation } from '@/hooks/use-debounced-navigation';
 import { ChevronLeft, Download, FileText, ScanText } from 'lucide-react-native';
@@ -72,22 +73,7 @@ export default function ImportWalletScreen() {
   };
 
   const validateSeedPhrase = (phrase: string): boolean => {
-    const words = phrase
-      .trim()
-      .split(' ')
-      .filter(word => word.length > 0);
-
-    // Check if we have exactly 12 or 24 words
-    if (words.length !== 12 && words.length !== 24) {
-      return false;
-    }
-
-    // Basic word validation - each word should be at least 3 characters
-    const validWords = words.every(
-      word => word.length >= 3 && /^[a-z]+$/.test(word) // only lowercase letters
-    );
-
-    return validWords;
+    return bip39.validateMnemonic(phrase, bip39.wordlists.english);
   };
 
   const handleImportWallet = () => {


### PR DESCRIPTION
# Description
Add seed phrase validation to the import wallet UI.

## Motivation and Context
This is to let a user know if a seed phrase is misspelled when initialising the wallet.

## Type of change
New feature (non-breaking change which adds functionality)