### PR TITLE
Add preinstall script to ensure transient deps are available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@tetherto/wdk-starter-react-native",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-starter-react-native",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
+      "hasInstallScript": true,
       "dependencies": {
         "@craftzdog/react-native-buffer": "^6.1.0",
         "@expo/vector-icons": "^15.0.2",
@@ -6689,17 +6690,6 @@
         "superstruct": "^2.0.2"
       }
     },
-    "node_modules/@solana/web3.js/node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/@solana/web3.js/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -7081,9 +7071,9 @@
       }
     },
     "node_modules/@tetherto/pear-wrk-wdk": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@tetherto/pear-wrk-wdk/-/pear-wrk-wdk-1.0.0-beta.4.tgz",
-      "integrity": "sha512-R/F05BGxwkTdN+FF0vYBBvwbISWgQ+p1EAiqlGjBS3ySgJpFhZP9NU2hCbZtLN+BrgU9Jf6rq1CVzknsZ22uaw==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@tetherto/pear-wrk-wdk/-/pear-wrk-wdk-1.0.0-beta.5.tgz",
+      "integrity": "sha512-LaqXxzhmRpd0KYkLThDXtd+bX4ClHU8gnxaNQInyBaFPRWUsqv0JqAU/wFmfoEUY/RcHrxqe5+EqNcF0MyE1+A==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7167,43 +7157,6 @@
         "stream-http": "^3.2.0"
       }
     },
-    "node_modules/@tetherto/wdk-secret-manager": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@tetherto/wdk-secret-manager/-/wdk-secret-manager-1.0.0-beta.3.tgz",
-      "integrity": "sha512-qdxi9qj/ukvYAC/bLtoX1lNp0PHW546pJoxTScizriy+RYdkCpkRHatWoBxJ/29khQNjoFSNFbqe8YR/2xZfSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "b4a": "^1.6.7",
-        "bare-crypto": "^1.7.0",
-        "bare-stream": "^2.6.5",
-        "bip39": "^3.1.0",
-        "bip39-mnemonic": "^2.5.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "rimraf": "^5.0.10",
-        "sodium-javascript": "^0.8.0",
-        "sodium-native": "^5.0.6",
-        "sodium-universal": "^5.0.1",
-        "typescript": "^5.8.3"
-      }
-    },
-    "node_modules/@tetherto/wdk-secret-manager/node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@tetherto/wdk-uikit-react-native": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/@tetherto/wdk-uikit-react-native/-/wdk-uikit-react-native-1.0.0-beta.2.tgz",
@@ -7228,19 +7181,6 @@
       },
       "peerDependencies": {
         "@ton/core": ">=0.59.0"
-      }
-    },
-    "node_modules/@ton/core": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.62.0.tgz",
-      "integrity": "sha512-GCYlzzx11rSESKkiHvNy9tL8zWth+ZtUbvV29WH478FvBp8xTw24AyoigwXWNV+OLCAcnwlGhZpTpxjD3wzCwA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "symbol.inspect": "1.0.1"
-      },
-      "peerDependencies": {
-        "@ton/crypto": ">=3.2.0"
       }
     },
     "node_modules/@ton/crypto": {
@@ -7468,7 +7408,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -10934,18 +10874,6 @@
         "@noble/hashes": "^1.2.0"
       }
     },
-    "node_modules/bip39-mnemonic": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bip39-mnemonic/-/bip39-mnemonic-2.5.0.tgz",
-      "integrity": "sha512-hgCxFHN129ta0bHl9VPykoqCPagBUr2oaXjfSbfeXAPe+y/byxwjPFFEFTMNO/1T/GSoMP1cOXHa2ZaprHG1kg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "b4a": "^1.6.6",
-        "nanoassert": "^2.0.0",
-        "sodium-universal": "^5.0.1"
-      }
-    },
     "node_modules/bitcoinjs-lib": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
@@ -12243,17 +12171,6 @@
         "node-fetch": "^2.7.0"
       }
     },
-    "node_modules/cross-fetch/node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/cross-fetch/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -12409,7 +12326,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -15582,13 +15499,6 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -16695,7 +16605,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -23249,7 +23159,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safety-catch": {
@@ -25256,6 +25166,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tetherto/wdk-starter-react-native",
   "main": "expo-router/entry",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit",
     "prebuild": "expo prebuild",
     "prebuild:clean": "expo prebuild --clean",
+    "preinstall": "npm install @tetherto/pear-wrk-wdk --ignore-scripts --legacy-peer-deps 2>/dev/null || true",
     "test:e2e": "export ANDROID_HOME=$HOME/Library/Android/sdk && export PATH=$PATH:$ANDROID_HOME/platform-tools && wdio run test/wdio.conf.ts",
     "test:e2e:ios": "export ANDROID_HOME=$HOME/Library/Android/sdk && export PATH=$PATH:$ANDROID_HOME/platform-tools && wdio run test/wdio.ios.conf.ts",
     "test:e2e:android": "export ANDROID_HOME=$HOME/Library/Android/sdk && export PATH=$PATH:$ANDROID_HOME/platform-tools && wdio run test/wdio.conf.ts",


### PR DESCRIPTION
# Description
Add preinstall script to ensure transient deps are available

## Motivation and Context
npm installs dependencies in a non-deterministic order, and optional peer deps of transitive dependencies (like ws used by ethers) aren't guaranteed to be available when postinstall scripts execute. 

The pear-wrk-wdk postinstall runs npm run gen:mobile-bundle which uses bare-pack to traverse the module tree. When it hits ethers → ws, it tries to resolve the optional deps which might not be installed yet.

I added a preinstall script ran first and pre-fetched @tetherto/pear-wrk-wdk with all its transitive deps, so when the main install ran and the postinstall script executed, everything is already in place

## Related Issue
N/A 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update