### PR TITLE
fix: use currentWalletId instead of hardcoded 'default' in assets

### DIFF
--- a/src/app/assets.tsx
+++ b/src/app/assets.tsx
@@ -121,7 +121,7 @@ export default function AssetsScreen() {
     router.push({
       pathname: '/token-details',
       params: {
-        walletId: 'default',
+        walletId: currentWalletId,
         token: asset.id,
       },
     });


### PR DESCRIPTION
## Summary
- Fix hardcoded `walletId: 'default'` in `handleAssetPress` function in `assets.tsx`
- Now uses the dynamically determined `currentWalletId` variable instead

## Test plan
- [ ] Navigate to Assets screen
- [ ] Tap on an asset
- [ ] Verify token details screen loads correctly with the active wallet