### PR TITLE
feat: add Plasma network configuration for future support

### DIFF
--- a/src/config/get-chains-config.ts
+++ b/src/config/get-chains-config.ts
@@ -77,6 +77,21 @@ const getChainsConfig = () => {
         address: 'TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf',
       },
     },
+    // Plasma Network (Testnet) - Requires NetworkType.PLASMA support in WDK provider
+    // Chain info: https://chainlist.org/chain/9746
+    plasma: {
+      chainId: 9746, // Plasma Testnet (Mainnet is 9745)
+      blockchain: 'plasma',
+      provider: 'https://testnet-rpc.plasma.to',
+      // Note: Plasma uses native gas (XPL token), no bundler/paymaster setup yet
+      // bundlerUrl: '', // To be configured when available
+      // paymasterUrl: '', // To be configured when available
+      // paymasterAddress: '', // To be configured when available
+      entrypointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032', // Standard ERC-4337 entrypoint
+      transferMaxFee: 5000000,
+      swapMaxFee: 5000000,
+      bridgeMaxFee: 5000000,
+    },
   };
 };
 


### PR DESCRIPTION
Add Plasma testnet (chain ID 9746) to chains config in preparation for NetworkType.PLASMA support in the WDK provider.

https://claude.ai/code/session_01USaL2o4L9fjXR6hHYu3wam

# Description
<!--- Describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here: -->
PR fixes the following issue: 

## Type of change
<!-- Select the most suitable choice and remove the others from the checklist. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update