### PR TITLE
ci: add pull-request checks for typecheck and workflow lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,99 @@
+# CI — fast, secret-free checks that gate every pull request.
+#
+# Deliberately does NOT build the app. Build and Publish (build-and-publish.yaml)
+# owns native builds; it needs signing credentials, self-hosted/macOS runners and
+# tens of minutes. Everything here runs on ubuntu-latest in a couple of minutes
+# and needs no secrets, so it is safe to run on any pull request.
+#
+# docs/CONTRIBUTING.md asks contributors to run `npm run typecheck` before a PR.
+# This workflow is what makes that instruction enforceable rather than optional.
+#
+# Not included, and why:
+#   - `npm run lint` (`expo lint`): no ESLint config is committed and neither
+#     `eslint` nor `eslint-config-expo` is in devDependencies, so the first run
+#     triggers Expo's interactive setup. It would hang or fail here. Wire the
+#     config up first, then add a job.
+#   - `prettier --check`: prettier is installed but has no config file, so it
+#     falls back to its own defaults rather than prettier-config-standard. The
+#     tree does not currently match those defaults; enabling this needs a
+#     repo-wide reformat first, which is a separate decision.
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+# Opposite of Build and Publish's queue-don't-cancel policy: these checks have no
+# side effects, so superseding an in-flight run on a force-push is free.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  EXPO_NO_TELEMETRY: "1"
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      # Node/npm setup is inlined rather than reusing .github/actions/setup-eas,
+      # which also installs the EAS CLI — a large download this job has no use
+      # for. Keep the Node version and the npm floor in sync with that action.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # docs/ENVIRONMENT.md: npm 10 silently drops packages from git-dependency
+      # trees with no error, and this project has three git dependencies.
+      # Node 22 ships npm 10.x, hence the explicit upgrade.
+      - name: Upgrade npm
+        run: |
+          npm install --global npm@^11
+          npm --version
+
+      - name: Install dependencies
+        # `--ignore-scripts` skips postinstall → `wdk-worklet-bundler generate`,
+        # which spends minutes producing an 11 MB worklet bundle that tsc never
+        # reads: src/app/_layout.tsx's import of the bundle is satisfied by the
+        # wildcard ambient declaration in src/wdk/bundle.d.ts, so typechecking
+        # succeeds with .wdk-bundle/ absent. Verified, not assumed.
+        #
+        # `npm install` rather than `npm ci` — npm/cli#8726 makes `npm ci` reject
+        # a lockfile that `npm install` itself just wrote. See docs/ENVIRONMENT.md.
+        run: npm install --ignore-scripts --no-audit --no-fund
+
+      - name: Typecheck
+        run: npm run typecheck
+
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      # Pinned to an exact release rather than tracking main, so a change
+      # upstream can never alter what runs against this repository. The
+      # self-hosted runner labels this project uses are declared in
+      # .github/actionlint.yaml, which actionlint picks up automatically.
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}"
+          ./actionlint -color


### PR DESCRIPTION
# Description

Adds `.github/workflows/ci.yaml` — a secret-free CI workflow that runs on pull requests, with two jobs on `ubuntu-latest`:

- **Typecheck** — `tsc --noEmit` under the existing strict `tsconfig.json`
- **Lint workflows** — `actionlint`, pinned to 1.7.12, picking up the self-hosted runner labels already declared in `.github/actionlint.yaml`

It deliberately does not build the app. `build-and-publish.yaml` owns native builds; it needs signing credentials and macOS/self-hosted runners and takes tens of minutes. This runs in under a minute and needs no secrets, so it is safe on any pull request, including from forks.

## Motivation and Context

`docs/CONTRIBUTING.md` asks contributors to run `npm run typecheck` before opening a PR, but nothing enforced it. The only workflow in the repository is `build-and-publish.yaml`, which is `workflow_dispatch`-only and never runs `tsc`, and there are no git hooks. A type regression could therefore land unnoticed and only surface whenever someone next happened to run the check locally.

The tree is currently green, so this gates from day one without blocking any existing work.

## Implementation notes

**Install uses `--ignore-scripts`.** This skips `postinstall` → `wdk-worklet-bundler generate`, which spends minutes producing an 11 MB worklet bundle that `tsc` never reads: the bundle import in `src/app/_layout.tsx` is satisfied by the wildcard ambient declaration in `src/wdk/bundle.d.ts`. Verified against a clean clone — `npm install --ignore-scripts` followed by `tsc --noEmit` exits 0 with `.wdk-bundle/` absent. Neither git dependency that `src/` imports (`wdk-backup-cloud`, `wdk-indexer-http`) has a `prepare` build step; both ship committed types.

**`npm install` rather than `npm ci`** — npm/cli#8726 makes `npm ci` reject a lockfile that `npm install` itself just wrote, as noted in `docs/ENVIRONMENT.md`. npm is upgraded to 11 before installing, for the git-dependency reason documented in the same file and in `.github/actions/setup-eas`.

**Node setup is inlined** rather than reusing `.github/actions/setup-eas`, which also installs the EAS CLI — a large download this job has no use for. The duplication is called out in a comment so the Node version and npm floor stay in sync.

## Intentionally left out

Both are recorded in comments at the top of the workflow, with what each would need first:

- **`npm run lint`** — no ESLint config is committed and neither `eslint` nor `eslint-config-expo` is in `devDependencies`, so the first run triggers Expo's interactive setup and would hang in CI.
- **`prettier --check`** — prettier is installed but has no config file, so it falls back to its own defaults rather than `prettier-config-standard`. The tree does not currently match those defaults, so enabling this needs a repo-wide reformat — a separate decision.

## Verification

- `actionlint` clean on both this workflow and `build-and-publish.yaml`
- `npm run typecheck` exits 0 on this branch
- The exact CI sequence (clean clone → `npm install --ignore-scripts` → `tsc --noEmit`) reproduced locally, exit 0
- Both jobs ran green on an equivalent PR on a fork: Lint workflows 4s, Typecheck 51s

## Note for maintainers

This targets `main` rather than `develop` because `develop` has not been updated since 2026-04-25 and predates `New WDK Starter RN App (#38)`. It has no `.github/actionlint.yaml` and no `src/wdk/bundle.d.ts` — the two files this workflow's actionlint job and `--ignore-scripts` optimization respectively depend on — and its `package.json` differs (Jest, no `postinstall`). The workflow as written would not be correct there. Happy to retarget if you would rather land it elsewhere.

## Related Issue

No related issue — raising directly as a CI/infrastructure change. Happy to open one first if you would prefer that.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)