### PR TITLE
ci: harden release workflow against credential residue and tag drift

### DIFF
--- a/.github/actions/setup-eas/action.yaml
+++ b/.github/actions/setup-eas/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Keeps the SHA-pinned actions in .github/workflows and .github/actions current.
+#
+# The pins exist because those steps run in the same job as the decoded signing
+# credentials (see the header of build-and-publish.yaml). A pin nobody refreshes
+# is just an old version, so this file is the other half of that decision — it
+# turns each upgrade into a reviewable PR instead of a silent tag move.
+#
+# Two directory entries, deliberately: for the github-actions ecosystem
+# Dependabot only scans /.github/workflows plus an action.yml in the repository
+# *root*. Composite actions under .github/actions/ are invisible without an
+# explicit entry, and setup-eas pins actions/setup-node.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -12,9 +12,16 @@
 # production store listing — iOS uploads land in TestFlight and Android submits
 # to the Play "internal" track (configured in eas.json).
 #
-# No credential cleanup step is needed: the decoded keystore, certs and
-# credentials.json are all untracked, so checkout's default `git clean -ffdx`
-# removes them at the start of the next run.
+# The Android job ends with an explicit credential cleanup step. Checkout's
+# default `git clean -ffdx` does remove the untracked keystore, credentials.json
+# and .env — but only at the start of the *next* run, and the Android job runs
+# on a self-hosted runner where that leaves them readable on disk in between.
+# The iOS job needs no equivalent: `macos-26-xlarge` is GitHub-hosted and torn
+# down when the job ends.
+#
+# Every third-party action is pinned to a full commit SHA rather than a tag,
+# since those steps run in the same job as the decoded signing material. See
+# .github/dependabot.yml, which is what keeps the pins current.
 #
 # See docs/RELEASE.md for the secret inventory and one-time setup.
 name: Build and Publish
@@ -44,8 +51,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only by default. Only push-tag writes to the repository, and it raises
+# its own permission to `contents: write` at the job level.
 permissions:
-  contents: write
+  contents: read
 
 env:
   EXPO_NO_TELEMETRY: "1"
@@ -104,7 +113,7 @@ jobs:
           df -h
 
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: ./.github/actions/setup-eas
 
@@ -116,13 +125,13 @@ jobs:
 
       - name: Setup Java 17
         # docs/ENVIRONMENT.md: JDK 21/24 break Android codegen for this project.
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
       - uses: ./.github/actions/write-dotenv
 
@@ -164,7 +173,7 @@ jobs:
           echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-app-release.aab
           path: ${{ steps.build.outputs.artifact }}
@@ -186,6 +195,24 @@ jobs:
             --profile production \
             --path "${{ steps.build.outputs.artifact }}" \
             --non-interactive
+
+      # This runner is not ephemeral, so nothing here can be left for the next
+      # run's `git clean` to deal with. Last step in the job and `always()`, so
+      # a failed build is cleaned up too.
+      #
+      # The temp sweep is a safety net rather than the usual path:
+      # eas-cli-local-build-plugin removes its own workingdir in a `finally`,
+      # but a cancelled or OOM-killed run leaves behind a full copy of the
+      # project — keystore included. The path comes from `env-paths`, which on
+      # Linux is <tmpdir>/<username>/eas-build-local-nodejs; the username
+      # segment is why this is a glob and not a literal.
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          rm -f credentials.json google-service-account.json .env
+          rm -rf android/keystores
+          rm -rf "${TMPDIR:-/tmp}"/*/eas-build-local-nodejs \
+                 "${TMPDIR:-/tmp}"/eas-build-local-nodejs || true
 
   ios:
     name: iOS → TestFlight
@@ -224,7 +251,7 @@ jobs:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: ./.github/actions/select-xcode
 
@@ -270,7 +297,7 @@ jobs:
           echo "artifact=$ARTIFACT" >> "$GITHUB_OUTPUT"
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-app-release.ipa
           path: ${{ steps.build.outputs.artifact }}
@@ -304,9 +331,13 @@ jobs:
     # dispatch (where the other job is skipped) still tags.
     if: ${{ !cancelled() && inputs.pushTag && needs.android.result != 'failure' && needs.ios.result != 'failure' }}
     runs-on: ubuntu-latest
+    # The only job that writes to the repository, hence the only one that
+    # raises above the workflow-level `contents: read`.
+    permissions:
+      contents: write
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Push dated tag
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,11 @@ app-example
 .env
 .npmrc
 
+# local signing credentials — see docs/RELEASE.md. Written by the release
+# workflow and created by hand for local `eas build`; never commit either.
+credentials.json
+google-service-account.json
+
 # E2E tests
 test/apps/
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -66,8 +66,11 @@ All secrets live in the **`release`** GitHub Environment (both build jobs declar
 | `APPLE_API_ISSUER_ID` | plain | ASC API issuer ID. |
 | `APPLE_TEAM_ID` | plain | Apple Developer team ID. |
 
-`credentials.json` is never committed — it exists only as `CREDENTIALS_JSON`. Its shape, with the
-paths the workflow actually writes:
+`credentials.json` is never committed — it exists only as `CREDENTIALS_JSON`. It and
+`google-service-account.json` are both in `.gitignore`, which matters because this repo is public and
+the second one holds a Play Developer API key. If you create either by hand for a local
+`eas build`/`eas submit`, that is what stops a stray `git add -A` from publishing it. Its shape, with
+the paths the workflow actually writes:
 
 ```json
 {
@@ -164,10 +167,18 @@ Not yet done — the workflow will not go green until these are complete.
    `io.tether.wdk.starter.reactnative`). Without it Google Sign-In fails with
    `DEVELOPER_ERROR (10)` in release builds only — debug builds keep working. See
    [CLOUD_BACKUP.md](CLOUD_BACKUP.md).
-5. **Confirm runner access.** The Android job targets the self-hosted `app-build-linux-x64` label and
-   iOS targets `macos-26-xlarge`. This repository is public, so confirm with whoever owns the runner
-   that pointing it at a public repo is acceptable, and that large macOS minutes are budgeted.
-   Swapping to `ubuntu-latest` / `macos-latest` is a two-line change if not.
+5. **Confirm runner access, and that the runner is dedicated.** The Android job targets the
+   self-hosted `app-build-linux-x64` label and iOS targets `macos-26-xlarge`. This repository is
+   public, so confirm with whoever owns the runner that pointing it at a public repo is acceptable,
+   and that large macOS minutes are budgeted. Swapping to `ubuntu-latest` / `macos-latest` is a
+   two-line change if not.
+
+   Separately, confirm that `app-build-linux-x64` is **dedicated to this repository**. Unlike the
+   GitHub-hosted iOS runner it is not destroyed after the job, so any other repo sharing that label
+   runs jobs on the same filesystem this one decodes the release keystore onto. The Android job's
+   final *Cleanup credentials* step narrows that window but does not close it — a job interleaved on
+   a shared runner would still see the workspace mid-build. GitHub's own guidance is not to use
+   self-hosted runners with public repositories for this reason.
 
 ## Verifying a release
 


### PR DESCRIPTION
Security hardening for `build-and-publish.yaml`. No change to what the workflow does — same jobs, same steps, same order, same build/submit commands.

- **Credential cleanup on Android.** The self-hosted runner is not ephemeral, so the decoded keystore, `credentials.json`, `google-service-account.json` and `.env` sat on disk until the *next* run's `git clean`. Added a final `if: always()` step. The temp sweep covers cancelled/OOM-killed runs — `eas-cli-local-build-plugin` removes its own workingdir in a `finally`, but not when the process dies. The path is a glob because `env-paths` on Linux resolves to `<tmpdir>/<username>/eas-build-local-nodejs`. iOS needs no equivalent: `macos-26-xlarge` is GitHub-hosted.
- **Pinned all five external actions to full SHAs.** Each SHA is the current tip of the major line the tag already resolved to, so no version actually changes. Added `.github/dependabot.yml` to keep them current — it needs two directory entries, since for `github-actions` Dependabot only scans `.github/workflows` plus a *root* `action.yml`, and `setup-eas` pins `setup-node`.
- **Gitignored `credentials.json` and `google-service-account.json`.** They were the only two credential files not ignored, on a public repo where `RELEASE.md` tells maintainers to create them by hand. Neither was ever tracked.
- **Narrowed `permissions` to `contents: read`**, raised to `write` on `push-tag` alone — the only job that writes to the repo. `upload-artifact` uses `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`.

`RELEASE.md` also now asks maintainers to confirm `app-build-linux-x64` is dedicated to this repository — the cleanup step narrows that window, but a shared non-ephemeral runner would still see the workspace mid-build.

**Verification:** `actionlint` (exit 0), `git check-ignore`, and a full diff review confirming no step reordered and no existing `run:` body altered. Runtime verification still needs a dispatched `buildTarget: android` run.