### PR TITLE
fix(android): add R8 keep rules for Spark SDK's JNA and Guava references

### DIFF
--- a/app.json
+++ b/app.json
@@ -78,7 +78,8 @@
             "compileSdkVersion": 36,
             "buildToolsVersion": "36.0.0",
             "enableProguardInReleaseBuilds": true,
-            "enableShrinkResourcesInReleaseBuilds": true
+            "enableShrinkResourcesInReleaseBuilds": true,
+            "extraProguardRules": "-dontwarn com.google.j2objc.annotations.ReflectionSupport\n-dontwarn com.google.j2objc.annotations.RetainedWith\n-dontwarn java.awt.Component"
           }
         }
       ],


### PR DESCRIPTION
# Description

Adds three `-dontwarn` rules to the `expo-build-properties` config in `app.json`, so
R8 can complete a release build.

# Motivation and Context

`assembleRelease` currently fails on a clean clone of `main`:

```
ERROR: Missing classes detected while running R8.
ERROR: R8: Missing class com.google.j2objc.annotations.ReflectionSupport (referenced from: com.google.common.util.concurrent.AbstractFuture)
       Missing class com.google.j2objc.annotations.RetainedWith (referenced from: com.google.common.collect.ImmutableMap.entrySet)
       Missing class java.awt.Component (referenced from: com.sun.jna.Native.getWindowHandle0)

Execution failed for task ':app:minifyReleaseWithR8'.
```

`@buildonspark/spark-sdk` brings in Guava and JNA, whose optional compile-time
annotations aren't on the Android classpath. `app.json` enables
`enableProguardInReleaseBuilds`, so every release build runs R8 and hits this.

The three classes are a desktop AWT type and two j2objc annotations — none reachable
on Android, so suppressing the warnings is the intended fix (it's what R8's own
`missing_rules.txt` suggests).

`android/` is generated and gitignored, so editing `proguard-rules.pro` directly
doesn't survive `expo prebuild --clean`. Routing the rules through
`expo-build-properties` puts them in the tracked config and regenerates them each
prebuild.

## Reproduce

```
git clone https://github.com/tetherto/wdk-starter-react-native
cd wdk-starter-react-native && npm install
npx expo prebuild --platform android
cd android && ./gradlew assembleRelease
```

Fails at `:app:minifyReleaseWithR8`. Debug builds are unaffected — they don't run R8.

## Verification

With the patch, `assembleRelease` completes and the resulting APK was installed and
launched on an arm64 emulator (API 35): the app renders its onboarding screen,
`libbare-kit.so` and the rest of the native graph load, no crash. Confirms the
minified build still runs, rather than only compiling.

## Why CI didn't catch it

`ci.yaml` runs typecheck and actionlint only, and installs with `--ignore-scripts`,
so nothing compiles Android. `build-and-publish.yaml` has run once, on 2026-08-11,
which predates #55 — the change that introduced the Spark SDK.

# Related Issue

PR fixes the following issue: _none filed — raising the fix directly. Happy to open
one if you'd prefer the paper trail._

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
